### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,21 @@
 import * as types from './types'
 
-export type DimensionProps = types.DimensionProps
-export type SpacingProps = types.SpacingProps
+declare module '@bernatfortet/global-styles' {
 
-export interface BoxProps extends types.BoxProps, types.WebBoxProps {}
+  // type exports
 
-export type s = types.s
+  type DimensionProps = types.DimensionProps
+  type SpacingProps = types.SpacingProps
 
-export type TextProps = types.TextProps
-export type Box = React.SFC<BoxProps & React.BaseHTMLAttributes<any>>
-export type Row = React.SFC<BoxProps & types.RowColProps & React.BaseHTMLAttributes<any>>
-export type Column = React.SFC<BoxProps & types.RowColProps & React.BaseHTMLAttributes<any>>
+  type BoxProps = types.BoxProps & types.WebBoxProps
 
+  type TextProps = types.TextProps
+
+  // declared constants (implementations in JS)
+
+  const s: types.s & types.WebBoxProps
+  const Box: React.SFC<BoxProps & React.BaseHTMLAttributes<any>>
+  const Row: React.SFC<BoxProps & types.RowColProps & React.BaseHTMLAttributes<any>>
+  const Column: React.SFC<BoxProps & types.RowColProps & React.BaseHTMLAttributes<any>>
+
+}

--- a/native.d.ts
+++ b/native.d.ts
@@ -1,14 +1,24 @@
 import * as React from 'react'
 import * as ReactNative from 'react-native'
+
 import * as types from './types'
 
-export type DimensionProps = types.DimensionProps
-export type SpacingProps = types.SpacingProps
-export type BoxProps = types.BoxProps
-export type s = types.s
+declare module '@bernatfortet/global-styles/native' {
 
-export type TextProps = types.TextProps
+  // type exports
 
-export type Box = React.ComponentType<BoxProps & ReactNative.ViewProperties>
-export type Row = React.ComponentType<BoxProps & types.RowColProps & ReactNative.ViewProperties>
-export type Column = React.ComponentType<BoxProps & types.RowColProps & ReactNative.ViewProperties>
+  type DimensionProps = types.DimensionProps
+  type SpacingProps = types.SpacingProps
+
+  type BoxProps = types.BoxProps
+
+  type TextProps = types.TextProps
+
+  // declared constants (implementations in JS)
+
+  export const s: types.s
+  export const Box: React.ComponentType<BoxProps & ReactNative.ViewProperties>
+  export const Row: React.ComponentType<BoxProps & types.RowColProps & ReactNative.ViewProperties>
+  export const Column: React.ComponentType<BoxProps & types.RowColProps & ReactNative.ViewProperties>
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bernatfortet/global-styles",
-  "version": "0.0.171",
+  "version": "0.0.172",
   "description": "Global Styles for styled-components",
   "main": "lib/index.js",
   "repository": {

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+import { Interpolation } from 'styled-components'
+
 export type DimensionProps = {
   w?: string | number,
   h?: string | number,
@@ -144,18 +146,18 @@ export type s = {
 }
 
 export type WebBoxProps = {
-  unselectable: boolean,
-  untouchable: boolean,
-  anim: boolean,
-  mediaDimensions: {
+  unselectable?: Interpolation<any>,
+  untouchable?: Interpolation<any>,
+  anim?: Interpolation<any>,
+  mediaDimensions?: {
     sm: number,
     md: number,
     lg: number,
   }
-  media: {
-    sm: () => void,
-    md: () => void,
-    lg: () => void,
+  media?: {
+    sm: (css: any) => any,
+    md: (css: any) => any,
+    lg: (css: any) => any,
   },
 } 
 


### PR DESCRIPTION
two keys:

1. You have to differentiate between types and actual classes. Types are used purely by the type system, and cannot be instantiated in code. These are defined with `type` and `interface`.

Instead, we use `const` to express that this is a variable that has a certain type. Box is not a type, it's a variable exported from the module.

2. I surround both native.d.ts and index.d.ts with a module namespace. This allows both typings to exist, and you import the one you want.